### PR TITLE
Improve toggle switch UX, add hover styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ To update the visible price tag based on the selected billing option, I used the
 
 Since this is only a one-pager, I could use an internal stylesheet so that CSS styles are always loaded.
 
-I could also sprinkle a little bit of JavaScript to enhance the toggle switch UX. For example, to add support for dragging the button from one option to another, or switching between the two states by pressing on the currently active option.
+I could also sprinkle a little bit of JavaScript to enhance the toggle switch UX. For example, to add support for dragging the button from one option to another, or ~~switching between the two states by pressing on the currently active option~~ (already implemented with CSS).
 
 ### Useful resources
 

--- a/style.css
+++ b/style.css
@@ -76,6 +76,16 @@ h2 {
   cursor: pointer; /* 3 */
 }
 
+/**
+ * To emulate toggle switch functionality, the inactive radio button will be:
+ * 1. stretched to span the width of the toggle switch
+ * 2. placed on top to get rid of the "dead" zone
+ */
+ .price-toggle input[type=radio]:not(:checked) {
+  width: 48px; /* 1 */
+  z-index: 10; /* 2 */
+}
+
 /* 1. Position the invisible radio buttons inside the toggle switch */
 .price-toggle input[type=radio][id=annually] {
   translate: calc(100% + 28px); /* 1 */
@@ -97,8 +107,17 @@ h2 {
   background: var(--clr-primary-gradient);
   border-radius: 99em;
   display: flex;
+  transition: .2s opacity;
   /* Initially place the button on the right since Monthly is selected by default */
   justify-content: flex-end;
+}
+
+.option:has(:hover) ~ .toggle-switch {
+  opacity: 50%;
+}
+
+.option:has(:active) ~ .toggle-switch {
+  opacity: 80%;
 }
 
 .toggle-button {
@@ -106,8 +125,6 @@ h2 {
   width: 24px;
   border-radius: 99em;
   transition: translate .2s cubic-bezier(0.76,0.05,0.86,0.06);
-  /* Place the toggle button above the invisible radio buttons so active option doesn't look selectable */
-  z-index: 10;
 }
 
 /* Add focus styles to toggle button when radio buttons are focused by keyboard */


### PR DESCRIPTION
This commit gets rid of the "dead" zone in the toggle switch, i.e., the area of the toggle button. Previously, clicking on the active area of the toggle switch doesn't "toggle" between the two options, since these are just radio buttons and clicking on an already active radio button does nothing.

To solve this, we make the inactive radio button span the width of the toggle switch and place it on top, so that clicking anywhere within the component will switch the active option just like a true toggle switch.

Apart from that, this doesn't break keyboard accessibility.

Clicking on a label won't toggle the switch; it will just select the corresponding option. This provides users with an explicit way to set the billing method. Besides, it would be weird to click on the Monthly label and have the billing method set to Annually.